### PR TITLE
Improved Fonts Render on first load

### DIFF
--- a/_includes/layouts/base.vto
+++ b/_includes/layouts/base.vto
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }} - José Luis Antúnez</title>
+    <link href="/columnas/fonts/pstimes-regular-webfont.woff2" rel="preload" as="font" type="font/woff2" />
     <link rel="stylesheet" href="/style.css">
     <link rel="alternate" type="application/rss+xml" title="Columnas de José Luis Antúnez" href="/feed.rss">
     <link rel="expect" blocking="render" href="#footer">

--- a/_includes/styles/variables.css
+++ b/_includes/styles/variables.css
@@ -5,6 +5,7 @@
   src: url("/fonts/pstimes-regular-webfont.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 :root {


### PR DESCRIPTION
Add font preloading before loading the CSS to prevent changes in font rendering once the CSS is applied.